### PR TITLE
Use 'mini.starter' as start screen

### DIFF
--- a/lua/lazyvim/plugins/ui.lua
+++ b/lua/lazyvim/plugins/ui.lua
@@ -137,6 +137,71 @@ return {
     },
   },
 
+  -- start screen
+  {
+    "echasnovski/mini.starter",
+    enabled = false,
+    event = "VimEnter",
+    config = function()
+      local logo = table.concat({
+        "██╗      █████╗ ███████╗██╗   ██╗██╗   ██╗██╗███╗   ███╗          Z",
+        "██║     ██╔══██╗╚══███╔╝╚██╗ ██╔╝██║   ██║██║████╗ ████║      Z",
+        "██║     ███████║  ███╔╝  ╚████╔╝ ██║   ██║██║██╔████╔██║   z",
+        "██║     ██╔══██║ ███╔╝    ╚██╔╝  ╚██╗ ██╔╝██║██║╚██╔╝██║ z",
+        "███████╗██║  ██║███████╗   ██║    ╚████╔╝ ██║██║ ╚═╝ ██║",
+        "╚══════╝╚═╝  ╚═╝╚══════╝   ╚═╝     ╚═══╝  ╚═╝╚═╝     ╚═╝",
+      }, "\n")
+      local pad = string.rep(" ", 22)
+      local new_section = function(name, action, section)
+        return { name = name, action = action, section = pad .. section }
+      end
+
+      local starter = require("mini.starter")
+      --stylua: ignore
+      local config = {
+        evaluate_single = true,
+        header = logo,
+        items = {
+          new_section("Find file",    "Telescope find_files", "Telescope"),
+          new_section("Recent files", "Telescope oldfiles",   "Telescope"),
+          new_section("Grep text",    "Telescope live_grep",  "Telescope"),
+          new_section("init.lua",     "e $MYVIMRC",           "Config"),
+          new_section("Lazy",         "Lazy",                 "Config"),
+          new_section("New file",     "ene | startinsert",    "Built-in"),
+          new_section("Quit",         "qa",                   "Built-in"),
+        },
+        content_hooks = {
+          starter.gen_hook.adding_bullet(pad .. "░ ", false),
+          starter.gen_hook.aligning("center", "center"),
+        },
+      }
+
+      -- close Lazy and re-open when starter is ready
+      if vim.o.filetype == "lazy" then
+        vim.cmd.close()
+        vim.api.nvim_create_autocmd("User", {
+          pattern = "MiniStarterOpened",
+          callback = function()
+            require("lazy").show()
+          end,
+        })
+      end
+
+      starter.setup(config)
+
+      vim.api.nvim_create_autocmd("User", {
+        pattern = "LazyVimStarted",
+        callback = function()
+          local stats = require("lazy").stats()
+          local ms = (math.floor(stats.startuptime * 100 + 0.5) / 100)
+          local pad_footer = string.rep(" ", 8)
+          MiniStarter.config.footer = pad_footer .. "⚡ Neovim loaded " .. stats.count .. " plugins in " .. ms .. "ms"
+          pcall(MiniStarter.refresh)
+        end,
+      })
+    end,
+  },
+
   -- dashboard
   {
     "goolord/alpha-nvim",


### PR DESCRIPTION
Hi!

This is a PR to give you options for a default start screen. Nothing against 'goolord/alpha.nvim', will totally understand rejecting this. 

Functionally it is almost the same:
- Press highlighted letter and it will execute corresponding command.
- User can also navigate to item with `<C-n>/<C-p>` or `<Down>/<Up>`.

Visually there are more differences:
- Items are automatically organized in sections.
- No easy way of adding different icons for different items. Instead there is a single bullet for all items serving as grouping symbol for sections.
- Padding for bullets, section names, and footer are picked manually to achieve some kind of alignment based on the header.

Here is a preview:
![lazyvim_mini-starter](https://user-images.githubusercontent.com/24854248/210395372-9d974bc3-c912-42cd-8d4f-9dd533139325.png)
